### PR TITLE
Finally dynamic dashboarding using ZOHO Done

### DIFF
--- a/dashboard_config.json
+++ b/dashboard_config.json
@@ -1,0 +1,65 @@
+[
+  {
+    "id": "4596d1df-4675-4ede-a8f6-3e865b938810",
+    "type": "sales",
+    "name": "dash1",
+    "url": "https://analytics.zoho.in/open-view/429819000001207408/21dcd9037acdf131eb1c2a1cad24f793",
+    "created_at": "2025-07-26T23:59:23.010644"
+  },
+  {
+    "id": "5654b47e-a137-4ae3-8181-d464edd605d5",
+    "type": "analytics",
+    "name": "dash2",
+    "url": "https://analytics.zoho.in/open-view/429819000001207408/21dcd9037acdf131eb1c2a1cad24f793",
+    "created_at": "2025-07-26T23:59:50.496587"
+  },
+  {
+    "id": "87d2a88a-7c29-402c-8945-8b5c79799c87",
+    "type": "admin",
+    "name": "DASH1",
+    "url": "https://analytics.zoho.in/open-view/429819000001207071/ab301c281e6e3b2c24162171d7a21991",
+    "created_at": "2025-07-27T00:37:22.009664"
+  },
+  {
+    "id": "7e713633-a006-45ae-92aa-3ac3650a0ff7",
+    "type": "admin",
+    "name": "DASH 2",
+    "url": "https://analytics.zoho.in/open-view/429819000001207071/ab301c281e6e3b2c24162171d7a21991",
+    "created_at": "2025-07-27T00:37:35.485865"
+  },
+  {
+    "id": "c34ad260-8c9f-4bc8-8725-14ce9b43be56",
+    "type": "cre",
+    "name": "DASH1",
+    "url": "https://analytics.zoho.in/open-view/429819000001207071/ab301c281e6e3b2c24162171d7a21991",
+    "created_at": "2025-07-27T00:37:46.974743"
+  },
+  {
+    "id": "c122bfe4-741b-49f8-bb45-f6beeec421e4",
+    "type": "cre",
+    "name": "DASH 2",
+    "url": "https://analytics.zoho.in/open-view/429819000001207071/ab301c281e6e3b2c24162171d7a21991",
+    "created_at": "2025-07-27T00:37:55.101871"
+  },
+  {
+    "id": "c9dbb8db-38b9-4112-abc9-a973e4d3b5d9",
+    "type": "ps",
+    "name": "DASH1",
+    "url": "https://analytics.zoho.in/open-view/429819000001207071/ab301c281e6e3b2c24162171d7a21991",
+    "created_at": "2025-07-27T00:38:03.307350"
+  },
+  {
+    "id": "8488801e-1f9a-4597-8575-43b754cc3702",
+    "type": "ps",
+    "name": "DASH 2",
+    "url": "https://analytics.zoho.in/open-view/429819000001207071/ab301c281e6e3b2c24162171d7a21991",
+    "created_at": "2025-07-27T00:38:11.435510"
+  },
+  {
+    "id": "47c085e1-772f-4fd4-b806-51675b0af1a4",
+    "type": "branch-head",
+    "name": "DASH1",
+    "url": "https://analytics.zoho.in/open-view/429819000001207071/ab301c281e6e3b2c24162171d7a21991",
+    "created_at": "2025-07-27T01:32:51.118064"
+  }
+]

--- a/templates/admin_dashboard.html
+++ b/templates/admin_dashboard.html
@@ -380,7 +380,7 @@
             <i class="fas fa-chart-bar"></i> Analytics & Reports
         </h3>
         <div class="row mb-4">
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="action-card">
                     <div class="action-icon">
                         <i class="fas fa-chart-bar"></i>
@@ -392,7 +392,19 @@
                     </a>
                 </div>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-3">
+                <div class="action-card">
+                    <div class="action-icon">
+                        <i class="fas fa-tachometer-alt"></i>
+                    </div>
+                    <div class="action-title">Manage Dashboards</div>
+                    <div class="action-description">Configure Zoho dashboard embeddings for different user types</div>
+                    <a href="{{ url_for('manage_dashboards') }}" class="btn btn-primary btn-action">
+                        <i class="fas fa-tachometer-alt"></i> Manage Dashboards
+                    </a>
+                </div>
+            </div>
+            <div class="col-md-3">
                 <div class="action-card">
                     <div class="action-icon">
                         <i class="fas fa-download"></i>
@@ -404,7 +416,7 @@
                     </a>
                 </div>
             </div>
-            <div class="col-md-4">
+            <div class="col-md-3">
                 <div class="action-card">
                     <div class="action-icon">
                         <i class="fas fa-shield-alt"></i>

--- a/templates/analytics.html
+++ b/templates/analytics.html
@@ -785,6 +785,16 @@
             </div>
         </div>
 
+        <!-- Zoho Dashboards Section -->
+        <div class="mb-4">
+            <h5 style="color: var(--airbnb-red); font-weight: 600; margin-bottom: 1rem;">
+                <i class="fas fa-tachometer-alt" style="color: var(--airbnb-red);"></i> Zoho Dashboards
+            </h5>
+            <div id="adminDashboardsContainer">
+                <!-- Admin dashboards will be loaded here -->
+            </div>
+        </div>
+
         <!-- Campaign/Platform/Lead Count Table -->
         <div class="table-container mb-4">
             <h5 style="color: var(--airbnb-red); font-weight: 600; margin-bottom: 1rem;">
@@ -1915,6 +1925,56 @@
             fetchNegativeCallAttempts();
         }
         document.addEventListener('DOMContentLoaded', function() { fetchNegativeCallAttempts(); });
+        
+        // Load admin dashboards
+        function loadAdminDashboards() {
+            console.log('Loading admin dashboards...'); // Debug log
+            fetch('/api/dashboards')
+                .then(response => response.json())
+                .then(data => {
+                    console.log('Admin Dashboards data:', data); // Debug log
+                    if (data.success && data.dashboards.admin) {
+                        const container = document.getElementById('adminDashboardsContainer');
+                        let html = '';
+                        
+                        data.dashboards.admin.forEach(dashboard => {
+                            html += `
+                                <div class="card mb-3">
+                                    <div class="card-header d-flex justify-content-between align-items-center">
+                                        <h6 class="mb-0">${dashboard.name}</h6>
+                                        <small class="text-muted">Added: ${new Date(dashboard.created_at).toLocaleDateString()}</small>
+                                    </div>
+                                    <div class="card-body p-0">
+                                        <iframe src="${dashboard.url}" 
+                                                style="width: 100%; height: 800px; border: none;" 
+                                                frameborder="0">
+                                        </iframe>
+                                    </div>
+                                </div>
+                            `;
+                        });
+                        
+                        if (html === '') {
+                            html = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No admin dashboards configured yet.</p></div>';
+                        }
+                        
+                        container.innerHTML = html;
+                    } else {
+                        const container = document.getElementById('adminDashboardsContainer');
+                        container.innerHTML = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No admin dashboards configured yet.</p></div>';
+                    }
+                })
+                .catch(error => {
+                    console.error('Error loading admin dashboards:', error);
+                    const container = document.getElementById('adminDashboardsContainer');
+                    container.innerHTML = '<div class="text-center text-danger py-4"><i class="fas fa-exclamation-triangle fa-3x mb-3"></i><p>Error loading dashboards. Please try again.</p></div>';
+                });
+        }
+        
+        // Load dashboards on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            loadAdminDashboards();
+        });
         </script>
     </div>
 

--- a/templates/branch_head_dashboard.html
+++ b/templates/branch_head_dashboard.html
@@ -22,6 +22,23 @@
             </div>
         </div>
     </div>
+    
+    <!-- Zoho Dashboards Section -->
+    <div class="row mb-3">
+        <div class="col-12">
+            <div class="card shadow-sm">
+                <div class="card-header bg-info text-white">
+                    <h5 class="mb-0"><i class="fas fa-tachometer-alt me-2"></i>Zoho Dashboards</h5>
+                </div>
+                <div class="card-body">
+                    <div id="branchHeadDashboardsContainer">
+                        <!-- Branch Head dashboards will be loaded here -->
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
     <!-- Universal Filter Section (no UID search or rows per page) -->
     <div class="row mb-3" id="universalFilterSection">
       <div class="col-md-3 mb-2">
@@ -989,5 +1006,73 @@ function loadSectionWithUrl(section, url) {
       if (pagDiv) pagDiv.innerHTML = '';
     });
 }
+
+// Load Branch Head dashboards
+function loadBranchHeadDashboards() {
+    console.log('Loading Branch Head dashboards...'); // Debug log
+    alert('Loading Branch Head dashboards...'); // Temporary alert
+    fetch('/api/dashboards')
+        .then(response => {
+            console.log('Branch Head API Response status:', response.status); // Debug log
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            console.log('Branch Head Dashboards data:', data); // Debug log
+            if (data.success && data.dashboards['branch-head']) {
+                const container = document.getElementById('branchHeadDashboardsContainer');
+                let html = '';
+                
+                data.dashboards['branch-head'].forEach(dashboard => {
+                    html += `
+                        <div class="card mb-3">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <h6 class="mb-0">${dashboard.name}</h6>
+                                <small class="text-muted">Added: ${new Date(dashboard.created_at).toLocaleDateString()}</small>
+                            </div>
+                            <div class="card-body p-0">
+                                <iframe src="${dashboard.url}" 
+                                        style="width: 100%; height: 800px; border: none;" 
+                                        frameborder="0">
+                                </iframe>
+                            </div>
+                        </div>
+                    `;
+                });
+                
+                if (html === '') {
+                    html = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No Branch Head dashboards configured yet.</p></div>';
+                }
+                
+                container.innerHTML = html;
+            } else {
+                console.log('No Branch Head dashboards found in response'); // Debug log
+                console.log('Response data:', data); // Debug log
+                const container = document.getElementById('branchHeadDashboardsContainer');
+                container.innerHTML = `<div class="text-center text-muted py-4">
+                    <i class="fas fa-chart-bar fa-3x mb-3"></i>
+                    <p>No Branch Head dashboards configured yet.</p>
+                    <small class="text-muted">Debug: Response received but no Branch Head dashboards found</small>
+                </div>`;
+            }
+        })
+        .catch(error => {
+            console.error('Error loading Branch Head dashboards:', error);
+            console.log('Error details:', error.message); // Debug log
+            const container = document.getElementById('branchHeadDashboardsContainer');
+            container.innerHTML = `<div class="text-center text-danger py-4">
+                <i class="fas fa-exclamation-triangle fa-3x mb-3"></i>
+                <p>Error loading dashboards. Please try again.</p>
+                <small class="text-muted">Debug: ${error.message}</small>
+            </div>`;
+        });
+}
+
+// Load dashboards on page load
+document.addEventListener('DOMContentLoaded', function() {
+    loadBranchHeadDashboards();
+});
 </script>
 {% endblock %} 

--- a/templates/cre_analytics.html
+++ b/templates/cre_analytics.html
@@ -150,6 +150,16 @@
     <h5 class="mb-0"><i class="fas fa-user-circle"></i> Analytics for: {{ analytics.current_cre }}</h5>
 </div>
 
+<!-- Zoho Dashboards Section -->
+<div class="mb-4">
+    <h5 style="color: var(--airbnb-red); font-weight: 600; margin-bottom: 1rem;">
+        <i class="fas fa-tachometer-alt" style="color: var(--airbnb-red);"></i> Zoho Dashboards
+    </h5>
+    <div id="creDashboardsContainer">
+        <!-- CRE dashboards will be loaded here -->
+    </div>
+</div>
+
 <!-- Date Filter -->
 <div class="filter-section">
     <div class="row">
@@ -513,6 +523,82 @@ document.addEventListener('DOMContentLoaded', function() {
             tableBody.innerHTML = html;
         }
     }
+});
+</script>
+
+<!-- Separate script for dashboard loading -->
+<script>
+// Load CRE dashboards
+function loadCreDashboards() {
+    console.log('Loading CRE dashboards...'); // Debug log
+    alert('Loading CRE dashboards...'); // Temporary alert to test if function is called
+    fetch('/api/dashboards')
+        .then(response => {
+            console.log('CRE API Response status:', response.status); // Debug log
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            console.log('CRE Dashboards data:', data); // Debug log
+            if (data.success && data.dashboards.cre) {
+                const container = document.getElementById('creDashboardsContainer');
+                console.log('Container found:', container); // Debug log
+                if (!container) {
+                    console.error('creDashboardsContainer not found!');
+                    return;
+                }
+                let html = '';
+                
+                console.log('CRE dashboards found:', data.dashboards.cre.length); // Debug log
+                
+                data.dashboards.cre.forEach(dashboard => {
+                    html += `
+                        <div class="card mb-3">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <h6 class="mb-0">${dashboard.name}</h6>
+                                <small class="text-muted">Added: ${new Date(dashboard.created_at).toLocaleDateString()}</small>
+                            </div>
+                            <div class="card-body p-0">
+                                <iframe src="${dashboard.url}" 
+                                        style="width: 100%; height: 600px; border: none;" 
+                                        frameborder="0">
+                                </iframe>
+                            </div>
+                        </div>
+                    `;
+                });
+                
+                if (html === '') {
+                    html = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No CRE dashboards configured yet.</p></div>';
+                }
+                
+                container.innerHTML = html;
+            } else {
+                console.log('No CRE dashboards found in response'); // Debug log
+                const container = document.getElementById('creDashboardsContainer');
+                container.innerHTML = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No CRE dashboards configured yet.</p><small class="text-muted">Debug: Response received but no CRE dashboards found</small></div>';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading CRE dashboards:', error);
+            const container = document.getElementById('creDashboardsContainer');
+            container.innerHTML = '<div class="text-center text-danger py-4"><i class="fas fa-exclamation-triangle fa-3x mb-3"></i><p>Error loading dashboards. Please try again.</p></div>';
+        });
+}
+
+// Load dashboards on page load
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('DOM loaded, calling loadCreDashboards...'); // Debug log
+    alert('DOM loaded, calling loadCreDashboards...'); // Temporary alert
+    loadCreDashboards();
+});
+
+// Also try loading when window loads
+window.addEventListener('load', function() {
+    console.log('Window loaded, calling loadCreDashboards...'); // Debug log
+    loadCreDashboards();
 });
 </script>
 {% endblock %} 

--- a/templates/manage_dashboards.html
+++ b/templates/manage_dashboards.html
@@ -1,0 +1,538 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manage Dashboards - Ather CRM</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Lexend:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --airbnb-red: #FF385C;
+            --airbnb-red-dark: #E31C5F;
+            --airbnb-gray-100: #F7F7F7;
+            --airbnb-gray-200: #EBEBEB;
+            --airbnb-gray-300: #DDDDDD;
+            --airbnb-gray-500: #717171;
+            --airbnb-gray-700: #222222;
+            --airbnb-white: #FFFFFF;
+            --airbnb-green: #00A699;
+            --airbnb-blue: #007A87;
+            --airbnb-yellow: #FFB400;
+            --airbnb-border-radius: 12px;
+            --airbnb-border-radius-lg: 16px;
+            --airbnb-shadow: 0 1px 2px rgba(0, 0, 0, 0.08), 0 4px 12px rgba(0, 0, 0, 0.05);
+            --airbnb-shadow-hover: 0 2px 4px rgba(0, 0, 0, 0.08), 0 8px 16px rgba(0, 0, 0, 0.1);
+        }
+
+        body {
+            font-family: 'Lexend', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            background: linear-gradient(135deg, var(--airbnb-gray-100) 0%, var(--airbnb-white) 100%);
+            min-height: 100vh;
+            color: var(--airbnb-gray-700);
+        }
+
+        .navbar {
+            background: var(--airbnb-white) !important;
+            border-bottom: 1px solid var(--airbnb-gray-200);
+            box-shadow: var(--airbnb-shadow);
+        }
+
+        .navbar-brand {
+            font-weight: 700;
+            color: var(--airbnb-red) !important;
+        }
+
+        .dashboard-container {
+            background: var(--airbnb-white);
+            border-radius: var(--airbnb-border-radius-lg);
+            box-shadow: var(--airbnb-shadow);
+            margin: 20px;
+            padding: 30px;
+            border: 1px solid var(--airbnb-gray-200);
+        }
+
+        .nav-tabs {
+            border-bottom: 2px solid var(--airbnb-gray-200);
+        }
+
+        .nav-tabs .nav-link {
+            border: none;
+            color: var(--airbnb-gray-500);
+            font-weight: 500;
+            padding: 15px 25px;
+            border-radius: var(--airbnb-border-radius) var(--airbnb-border-radius) 0 0;
+            transition: all 0.3s ease;
+        }
+
+        .nav-tabs .nav-link:hover {
+            color: var(--airbnb-red);
+            background-color: var(--airbnb-gray-100);
+        }
+
+        .nav-tabs .nav-link.active {
+            color: var(--airbnb-red);
+            background-color: var(--airbnb-white);
+            border-bottom: 3px solid var(--airbnb-red);
+        }
+
+        .dashboard-card {
+            background: var(--airbnb-white);
+            border: 1px solid var(--airbnb-gray-200);
+            border-radius: var(--airbnb-border-radius);
+            padding: 20px;
+            margin-bottom: 20px;
+            box-shadow: var(--airbnb-shadow);
+            transition: all 0.3s ease;
+        }
+
+        .dashboard-card:hover {
+            transform: translateY(-2px);
+            box-shadow: var(--airbnb-shadow-hover);
+        }
+
+        .dashboard-card .card-header {
+            background: none;
+            border-bottom: 1px solid var(--airbnb-gray-200);
+            padding-bottom: 15px;
+            margin-bottom: 15px;
+        }
+
+        .dashboard-card .card-title {
+            color: var(--airbnb-gray-700);
+            font-weight: 600;
+            margin: 0;
+        }
+
+        .dashboard-card .card-subtitle {
+            color: var(--airbnb-gray-500);
+            font-size: 0.9rem;
+            margin: 5px 0 0 0;
+        }
+
+        .btn-action {
+            padding: 8px 16px;
+            border-radius: var(--airbnb-border-radius);
+            font-weight: 500;
+            text-transform: none;
+            letter-spacing: 0;
+            transition: all 0.3s ease;
+            border: none;
+            font-size: 0.9rem;
+        }
+
+        .btn-primary {
+            background: var(--airbnb-red);
+            color: var(--airbnb-white);
+        }
+
+        .btn-success {
+            background: var(--airbnb-green);
+            color: var(--airbnb-white);
+        }
+
+        .btn-danger {
+            background: #DC3545;
+            color: var(--airbnb-white);
+        }
+
+        .btn-outline-secondary {
+            border: 1px solid var(--airbnb-gray-300);
+            color: var(--airbnb-gray-700);
+            background: var(--airbnb-white);
+        }
+
+        .btn-outline-secondary:hover {
+            background: var(--airbnb-gray-100);
+            border-color: var(--airbnb-gray-300);
+            color: var(--airbnb-gray-700);
+        }
+
+        .form-control {
+            border: 1px solid var(--airbnb-gray-300);
+            border-radius: var(--airbnb-border-radius);
+            padding: 12px 15px;
+            font-size: 0.95rem;
+        }
+
+        .form-control:focus {
+            border-color: var(--airbnb-red);
+            box-shadow: 0 0 0 0.2rem rgba(255, 56, 92, 0.25);
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 40px 20px;
+            color: var(--airbnb-gray-500);
+        }
+
+        .empty-state i {
+            font-size: 3rem;
+            margin-bottom: 20px;
+            color: var(--airbnb-gray-300);
+        }
+
+        .dashboard-preview {
+            background: var(--airbnb-gray-100);
+            border: 1px solid var(--airbnb-gray-200);
+            border-radius: var(--airbnb-border-radius);
+            padding: 15px;
+            margin-top: 15px;
+            font-family: monospace;
+            font-size: 0.85rem;
+            color: var(--airbnb-gray-600);
+            word-break: break-all;
+        }
+
+        .max-dashboards-warning {
+            background: #fff3cd;
+            border: 1px solid #ffeaa7;
+            color: #856404;
+            padding: 15px;
+            border-radius: var(--airbnb-border-radius);
+            margin-bottom: 20px;
+        }
+    </style>
+</head>
+<body>
+    <nav class="navbar navbar-expand-lg navbar-light">
+        <div class="container-fluid">
+            <a class="navbar-brand" href="#">
+                <i class="fas fa-bolt"></i> Ather CRM
+            </a>
+            <div class="d-flex align-items-center">
+                <span class="fw-semibold me-3"><i class="fas fa-user me-2"></i>Welcome, admin</span>
+                <a href="{{ url_for('admin_dashboard') }}" class="btn btn-outline-secondary me-2">
+                    <i class="fas fa-arrow-left"></i> Back to Dashboard
+                </a>
+                <a href="{{ url_for('logout') }}" class="btn btn-outline-secondary">
+                    <i class="fas fa-sign-out-alt"></i> Logout
+                </a>
+            </div>
+        </div>
+    </nav>
+
+    <div class="dashboard-container">
+        <div class="text-center mb-5">
+            <h1 class="display-4 mb-3">
+                <i class="fas fa-tachometer-alt text-primary"></i> Manage Dashboards
+            </h1>
+            <p class="lead">Configure Zoho dashboard embeddings for different user types</p>
+        </div>
+
+        <!-- Navigation Tabs -->
+        <ul class="nav nav-tabs" id="dashboardTabs" role="tablist">
+            <li class="nav-item" role="presentation">
+                <button class="nav-link active" id="admin-tab" data-bs-toggle="tab" data-bs-target="#admin" type="button" role="tab">
+                    <i class="fas fa-user-shield me-2"></i>Admin Dashboard
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="cre-tab" data-bs-toggle="tab" data-bs-target="#cre" type="button" role="tab">
+                    <i class="fas fa-headset me-2"></i>CRE Dashboard
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="ps-tab" data-bs-toggle="tab" data-bs-target="#ps" type="button" role="tab">
+                    <i class="fas fa-user-tie me-2"></i>PS Dashboard
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="branch-head-tab" data-bs-toggle="tab" data-bs-target="#branch-head" type="button" role="tab">
+                    <i class="fas fa-building me-2"></i>Branch Head Dashboard
+                </button>
+            </li>
+        </ul>
+
+        <!-- Tab Content -->
+        <div class="tab-content mt-4" id="dashboardTabContent">
+            <!-- Admin Dashboard Tab -->
+            <div class="tab-pane fade show active" id="admin" role="tabpanel">
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h3><i class="fas fa-user-shield text-primary"></i> Admin Dashboards</h3>
+                    <button class="btn btn-primary" onclick="showAddDashboardModal('admin')" id="addAdminBtn">
+                        <i class="fas fa-plus"></i> Add Dashboard
+                    </button>
+                </div>
+                
+                <div id="adminDashboardsList">
+                    <!-- Admin dashboards will be loaded here -->
+                </div>
+            </div>
+
+            <!-- CRE Dashboard Tab -->
+            <div class="tab-pane fade" id="cre" role="tabpanel">
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h3><i class="fas fa-headset text-success"></i> CRE Dashboards</h3>
+                    <button class="btn btn-success" onclick="showAddDashboardModal('cre')" id="addCreBtn">
+                        <i class="fas fa-plus"></i> Add Dashboard
+                    </button>
+                </div>
+                
+                <div id="creDashboardsList">
+                    <!-- CRE dashboards will be loaded here -->
+                </div>
+            </div>
+
+            <!-- PS Dashboard Tab -->
+            <div class="tab-pane fade" id="ps" role="tabpanel">
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h3><i class="fas fa-user-tie text-info"></i> PS Dashboards</h3>
+                    <button class="btn btn-info" onclick="showAddDashboardModal('ps')" id="addPsBtn">
+                        <i class="fas fa-plus"></i> Add Dashboard
+                    </button>
+                </div>
+                
+                <div id="psDashboardsList">
+                    <!-- PS dashboards will be loaded here -->
+                </div>
+            </div>
+
+            <!-- Branch Head Dashboard Tab -->
+            <div class="tab-pane fade" id="branch-head" role="tabpanel">
+                <div class="d-flex justify-content-between align-items-center mb-4">
+                    <h3><i class="fas fa-building text-warning"></i> Branch Head Dashboards</h3>
+                    <button class="btn btn-warning" onclick="showAddDashboardModal('branch-head')" id="addBranchHeadBtn">
+                        <i class="fas fa-plus"></i> Add Dashboard
+                    </button>
+                </div>
+                
+                <div id="branchHeadDashboardsList">
+                    <!-- Branch Head dashboards will be loaded here -->
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Add Dashboard Modal -->
+    <div class="modal fade" id="addDashboardModal" tabindex="-1">
+        <div class="modal-dialog modal-lg">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="modalTitle">Add Dashboard</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                </div>
+                <div class="modal-body">
+                    <form id="addDashboardForm">
+                        <input type="hidden" id="dashboardType" name="type">
+                        <div class="mb-3">
+                            <label for="dashboardName" class="form-label">Dashboard Name</label>
+                            <input type="text" class="form-control" id="dashboardName" name="name" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="dashboardUrl" class="form-label">Zoho Dashboard Embedding URL</label>
+                            <textarea class="form-control" id="dashboardUrl" name="url" rows="4" placeholder="Paste the Zoho dashboard embedding URL here..." required></textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">URL Preview</label>
+                            <div class="dashboard-preview" id="urlPreview">
+                                <em>Enter a URL to see preview...</em>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                    <button type="button" class="btn btn-primary" onclick="saveDashboard()">Save Dashboard</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        let currentDashboards = {};
+
+        // Load dashboards on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            loadAllDashboards();
+        });
+
+        // Load all dashboards
+        function loadAllDashboards() {
+            console.log('Loading all dashboards...'); // Debug log
+            fetch('/api/dashboards')
+                .then(response => {
+                    console.log('API Response status:', response.status); // Debug log
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    console.log('All dashboards data:', data); // Debug log
+                    if (data.success) {
+                        currentDashboards = data.dashboards;
+                        console.log('Current dashboards:', currentDashboards); // Debug log
+                        renderDashboards('admin');
+                        renderDashboards('cre');
+                        renderDashboards('ps');
+                        renderDashboards('branch-head');
+                    }
+                })
+                .catch(error => {
+                    console.error('Error loading dashboards:', error);
+                });
+        }
+
+        // Render dashboards for a specific type
+        function renderDashboards(type) {
+            console.log(`Rendering dashboards for type: ${type}`); // Debug log
+            let containerId;
+            if (type === 'branch-head') {
+                containerId = 'branchHeadDashboardsList';
+            } else {
+                containerId = type + 'DashboardsList';
+            }
+            const container = document.getElementById(containerId);
+            console.log(`Container for ${type} (ID: ${containerId}):`, container); // Debug log
+            const dashboards = currentDashboards[type] || [];
+            console.log(`Dashboards for ${type}:`, dashboards); // Debug log
+            
+            if (dashboards.length === 0) {
+                console.log(`No dashboards found for type: ${type}`); // Debug log
+                container.innerHTML = `
+                    <div class="empty-state">
+                        <i class="fas fa-chart-bar"></i>
+                        <h4>No dashboards configured</h4>
+                        <p>Click "Add Dashboard" to configure your first Zoho dashboard embedding.</p>
+                        <small class="text-muted">Debug: Type ${type} has no dashboards</small>
+                    </div>
+                `;
+                return;
+            }
+
+            let html = '';
+            dashboards.forEach((dashboard, index) => {
+                html += `
+                    <div class="dashboard-card">
+                        <div class="card-header d-flex justify-content-between align-items-start">
+                            <div>
+                                <h5 class="card-title">${dashboard.name}</h5>
+                                <p class="card-subtitle">Added on ${new Date(dashboard.created_at).toLocaleDateString()}</p>
+                            </div>
+                            <button class="btn btn-danger btn-sm" onclick="deleteDashboard('${dashboard.id}')">
+                                <i class="fas fa-trash"></i>
+                            </button>
+                        </div>
+                        <div class="dashboard-preview">
+                            ${dashboard.url}
+                        </div>
+                    </div>
+                `;
+            });
+
+            // Show warning if max dashboards reached
+            if (dashboards.length >= 5) {
+                html = `
+                    <div class="max-dashboards-warning">
+                        <i class="fas fa-exclamation-triangle me-2"></i>
+                        Maximum of 5 dashboards reached for this type. Remove one to add more.
+                    </div>
+                ` + html;
+            }
+
+            container.innerHTML = html;
+        }
+
+        // Show add dashboard modal
+        function showAddDashboardModal(type) {
+            const dashboards = currentDashboards[type] || [];
+            if (dashboards.length >= 5) {
+                alert('Maximum of 5 dashboards allowed per type. Please remove one first.');
+                return;
+            }
+
+            document.getElementById('dashboardType').value = type;
+            document.getElementById('dashboardName').value = '';
+            document.getElementById('dashboardUrl').value = '';
+            document.getElementById('urlPreview').innerHTML = '<em>Enter a URL to see preview...</em>';
+            
+            const typeNames = {
+                'admin': 'Admin',
+                'cre': 'CRE',
+                'ps': 'PS',
+                'branch-head': 'Branch Head'
+            };
+            
+            document.getElementById('modalTitle').textContent = `Add ${typeNames[type]} Dashboard`;
+            
+            const modal = new bootstrap.Modal(document.getElementById('addDashboardModal'));
+            modal.show();
+        }
+
+        // Preview URL
+        document.getElementById('dashboardUrl').addEventListener('input', function() {
+            const url = this.value;
+            const preview = document.getElementById('urlPreview');
+            
+            if (url.trim()) {
+                preview.textContent = url;
+            } else {
+                preview.innerHTML = '<em>Enter a URL to see preview...</em>';
+            }
+        });
+
+        // Save dashboard
+        function saveDashboard() {
+            const form = document.getElementById('addDashboardForm');
+            const formData = new FormData(form);
+            
+            fetch('/api/dashboards', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify({
+                    type: formData.get('type'),
+                    name: formData.get('name'),
+                    url: formData.get('url')
+                })
+            })
+            .then(response => response.json())
+            .then(data => {
+                if (data.success) {
+                    // Close modal
+                    const modal = bootstrap.Modal.getInstance(document.getElementById('addDashboardModal'));
+                    modal.hide();
+                    
+                    // Reload dashboards
+                    loadAllDashboards();
+                    
+                    // Show success message
+                    alert('Dashboard saved successfully!');
+                } else {
+                    alert('Error saving dashboard: ' + data.message);
+                }
+            })
+            .catch(error => {
+                console.error('Error saving dashboard:', error);
+                alert('Error saving dashboard. Please try again.');
+            });
+        }
+
+        // Delete dashboard
+        function deleteDashboard(id) {
+            if (confirm('Are you sure you want to delete this dashboard?')) {
+                fetch(`/api/dashboards/${id}`, {
+                    method: 'DELETE'
+                })
+                .then(response => response.json())
+                .then(data => {
+                    if (data.success) {
+                        loadAllDashboards();
+                        alert('Dashboard deleted successfully!');
+                    } else {
+                        alert('Error deleting dashboard: ' + data.message);
+                    }
+                })
+                .catch(error => {
+                    console.error('Error deleting dashboard:', error);
+                    alert('Error deleting dashboard. Please try again.');
+                });
+            }
+        }
+    </script>
+</body>
+</html> 

--- a/templates/ps_analytics.html
+++ b/templates/ps_analytics.html
@@ -85,6 +85,17 @@
         </div>
     </div>
 </div>
+
+<!-- Zoho Dashboards Section -->
+<div class="mb-4">
+    <h5 style="color: var(--airbnb-red); font-weight: 600; margin-bottom: 1rem;">
+        <i class="fas fa-tachometer-alt" style="color: var(--airbnb-red);"></i> Zoho Dashboards
+    </h5>
+    <div id="psDashboardsContainer">
+        <!-- PS dashboards will be loaded here -->
+    </div>
+</div>
+
 <style>
 .min-width-kpi { min-width: 260px; }
 .kpi-cards-row::-webkit-scrollbar { height: 8px; }
@@ -92,5 +103,67 @@
 </style>
 
 <!-- Add analytics content here -->
+
+<script>
+// Load PS dashboards
+function loadPsDashboards() {
+    console.log('Loading PS dashboards...'); // Debug log
+    fetch('/api/dashboards')
+        .then(response => {
+            console.log('PS API Response status:', response.status); // Debug log
+            if (!response.ok) {
+                throw new Error(`HTTP error! status: ${response.status}`);
+            }
+            return response.json();
+        })
+        .then(data => {
+            console.log('PS Dashboards data:', data); // Debug log
+            if (data.success && data.dashboards.ps) {
+                const container = document.getElementById('psDashboardsContainer');
+                let html = '';
+                
+                console.log('PS dashboards found:', data.dashboards.ps.length); // Debug log
+                
+                data.dashboards.ps.forEach(dashboard => {
+                    html += `
+                        <div class="card mb-3">
+                            <div class="card-header d-flex justify-content-between align-items-center">
+                                <h6 class="mb-0">${dashboard.name}</h6>
+                                <small class="text-muted">Added: ${new Date(dashboard.created_at).toLocaleDateString()}</small>
+                            </div>
+                            <div class="card-body p-0">
+                                                                    <iframe src="${dashboard.url}" 
+                                            style="width: 100%; height: 800px; border: none;" 
+                                            frameborder="0">
+                                </iframe>
+                            </div>
+                        </div>
+                    `;
+                });
+                
+                if (html === '') {
+                    html = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No PS dashboards configured yet.</p></div>';
+                }
+                
+                container.innerHTML = html;
+            } else {
+                console.log('No PS dashboards found in response'); // Debug log
+                const container = document.getElementById('psDashboardsContainer');
+                container.innerHTML = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No PS dashboards configured yet.</p><small class="text-muted">Debug: Response received but no PS dashboards found</small></div>';
+            }
+        })
+        .catch(error => {
+            console.error('Error loading PS dashboards:', error);
+            const container = document.getElementById('psDashboardsContainer');
+            container.innerHTML = '<div class="text-center text-danger py-4"><i class="fas fa-exclamation-triangle fa-3x mb-3"></i><p>Error loading dashboards. Please try again.</p></div>';
+        });
+}
+
+// Load dashboards on page load
+document.addEventListener('DOMContentLoaded', function() {
+    console.log('DOM loaded, calling loadPsDashboards...'); // Debug log
+    loadPsDashboards();
+});
+</script>
 
 {% endblock %} 


### PR DESCRIPTION
We have finally implemented the use of Zoho Analytics to make dashboards based on our database for various roles like admin, CRE, P S, and Branch Heads. In this commit, we have added
a manage dashboards section in the admin dashboard. In this section, we can add the authorized links of the Zoho dashboards we want to display in the system, and it will display these dashboards in various logins, like -
1) If a dashboard link is added to the admin dashboards, the respective dashboard will be visible in the analytics section of the admin dashboard
2) If a dashboard link is added to the CRE dashboard, the respective dashboard will be visible in the analytics section of the CRE dashboard
3) If a dashboard link is added to the PS dashboard, the respective dashboard will be visible in the analytics section the PS dashboard
4) If a dashboard link is added to the  Branch head dashboards, the respective dashboard will be visible in the Branch head login

For each section, you can add 5 dashboards with managed access to the dashboard. 
This makes the dashboard truly dynamic.