### PR TITLE
zoho robust

### DIFF
--- a/templates/branch_head_dashboard.html
+++ b/templates/branch_head_dashboard.html
@@ -1009,18 +1009,14 @@ function loadSectionWithUrl(section, url) {
 
 // Load Branch Head dashboards
 function loadBranchHeadDashboards() {
-    console.log('Loading Branch Head dashboards...'); // Debug log
-    alert('Loading Branch Head dashboards...'); // Temporary alert
     fetch('/api/dashboards')
         .then(response => {
-            console.log('Branch Head API Response status:', response.status); // Debug log
             if (!response.ok) {
                 throw new Error(`HTTP error! status: ${response.status}`);
             }
             return response.json();
         })
         .then(data => {
-            console.log('Branch Head Dashboards data:', data); // Debug log
             if (data.success && data.dashboards['branch-head']) {
                 const container = document.getElementById('branchHeadDashboardsContainer');
                 let html = '';
@@ -1060,12 +1056,10 @@ function loadBranchHeadDashboards() {
         })
         .catch(error => {
             console.error('Error loading Branch Head dashboards:', error);
-            console.log('Error details:', error.message); // Debug log
             const container = document.getElementById('branchHeadDashboardsContainer');
             container.innerHTML = `<div class="text-center text-danger py-4">
                 <i class="fas fa-exclamation-triangle fa-3x mb-3"></i>
                 <p>Error loading dashboards. Please try again.</p>
-                <small class="text-muted">Debug: ${error.message}</small>
             </div>`;
         });
 }

--- a/templates/cre_analytics.html
+++ b/templates/cre_analytics.html
@@ -528,77 +528,71 @@ document.addEventListener('DOMContentLoaded', function() {
 
 <!-- Separate script for dashboard loading -->
 <script>
-// Load CRE dashboards
-function loadCreDashboards() {
-    console.log('Loading CRE dashboards...'); // Debug log
-    alert('Loading CRE dashboards...'); // Temporary alert to test if function is called
-    fetch('/api/dashboards')
-        .then(response => {
-            console.log('CRE API Response status:', response.status); // Debug log
-            if (!response.ok) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-            return response.json();
-        })
-        .then(data => {
-            console.log('CRE Dashboards data:', data); // Debug log
-            if (data.success && data.dashboards.cre) {
-                const container = document.getElementById('creDashboardsContainer');
-                console.log('Container found:', container); // Debug log
-                if (!container) {
-                    console.error('creDashboardsContainer not found!');
-                    return;
-                }
-                let html = '';
-                
-                console.log('CRE dashboards found:', data.dashboards.cre.length); // Debug log
-                
-                data.dashboards.cre.forEach(dashboard => {
-                    html += `
-                        <div class="card mb-3">
-                            <div class="card-header d-flex justify-content-between align-items-center">
-                                <h6 class="mb-0">${dashboard.name}</h6>
-                                <small class="text-muted">Added: ${new Date(dashboard.created_at).toLocaleDateString()}</small>
-                            </div>
-                            <div class="card-body p-0">
-                                <iframe src="${dashboard.url}" 
-                                        style="width: 100%; height: 600px; border: none;" 
-                                        frameborder="0">
-                                </iframe>
-                            </div>
-                        </div>
-                    `;
-                });
-                
-                if (html === '') {
-                    html = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No CRE dashboards configured yet.</p></div>';
-                }
-                
-                container.innerHTML = html;
-            } else {
-                console.log('No CRE dashboards found in response'); // Debug log
-                const container = document.getElementById('creDashboardsContainer');
-                container.innerHTML = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No CRE dashboards configured yet.</p><small class="text-muted">Debug: Response received but no CRE dashboards found</small></div>';
-            }
-        })
-        .catch(error => {
-            console.error('Error loading CRE dashboards:', error);
+        // Load CRE dashboards
+        function loadCreDashboards() {
             const container = document.getElementById('creDashboardsContainer');
-            container.innerHTML = '<div class="text-center text-danger py-4"><i class="fas fa-exclamation-triangle fa-3x mb-3"></i><p>Error loading dashboards. Please try again.</p></div>';
+            if (!container) {
+                console.error('creDashboardsContainer not found!');
+                return;
+            }
+            
+            // Show loading state
+            container.innerHTML = '<div class="text-center text-muted py-4"><i class="fas fa-spinner fa-spin fa-3x mb-3"></i><p>Loading dashboards...</p></div>';
+            
+            fetch('/api/dashboards')
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error(`HTTP error! status: ${response.status}`);
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    if (data.success && data.dashboards && data.dashboards.cre && data.dashboards.cre.length > 0) {
+                        let html = '';
+                        
+                        data.dashboards.cre.forEach(dashboard => {
+                            if (dashboard && dashboard.url && dashboard.name) {
+                                html += `
+                                    <div class="card mb-3">
+                                        <div class="card-header d-flex justify-content-between align-items-center">
+                                            <h6 class="mb-0">${dashboard.name}</h6>
+                                            <small class="text-muted">Added: ${new Date(dashboard.created_at).toLocaleDateString()}</small>
+                                        </div>
+                                        <div class="card-body p-0">
+                                            <iframe src="${dashboard.url}" 
+                                                    style="width: 100%; height: 600px; border: none;" 
+                                                    frameborder="0"
+                                                    onerror="this.style.display='none'; this.parentElement.innerHTML='<div class=\'text-center text-danger py-4\'><i class=\'fas fa-exclamation-triangle fa-3x mb-3\'></i><p>Failed to load dashboard</p></div>';">
+                                            </iframe>
+                                        </div>
+                                    </div>
+                                `;
+                            }
+                        });
+                        
+                        if (html === '') {
+                            html = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No CRE dashboards configured yet.</p></div>';
+                        }
+                        
+                        container.innerHTML = html;
+                    } else {
+                        container.innerHTML = '<div class="text-center text-muted py-4"><i class="fas fa-chart-bar fa-3x mb-3"></i><p>No CRE dashboards configured yet.</p></div>';
+                    }
+                })
+                .catch(error => {
+                    console.error('Error loading CRE dashboards:', error);
+                    container.innerHTML = '<div class="text-center text-danger py-4"><i class="fas fa-exclamation-triangle fa-3x mb-3"></i><p>Error loading dashboards. Please try again.</p></div>';
+                });
+        }
+
+        // Load dashboards on page load
+        document.addEventListener('DOMContentLoaded', function() {
+            loadCreDashboards();
         });
-}
-
-// Load dashboards on page load
-document.addEventListener('DOMContentLoaded', function() {
-    console.log('DOM loaded, calling loadCreDashboards...'); // Debug log
-    alert('DOM loaded, calling loadCreDashboards...'); // Temporary alert
-    loadCreDashboards();
-});
-
-// Also try loading when window loads
-window.addEventListener('load', function() {
-    console.log('Window loaded, calling loadCreDashboards...'); // Debug log
-    loadCreDashboards();
-});
+        
+        // Also try loading when window loads
+        window.addEventListener('load', function() {
+            loadCreDashboards();
+        });
 </script>
 {% endblock %} 

--- a/templates/manage_dashboards.html
+++ b/templates/manage_dashboards.html
@@ -351,20 +351,16 @@
 
         // Load all dashboards
         function loadAllDashboards() {
-            console.log('Loading all dashboards...'); // Debug log
             fetch('/api/dashboards')
                 .then(response => {
-                    console.log('API Response status:', response.status); // Debug log
                     if (!response.ok) {
                         throw new Error(`HTTP error! status: ${response.status}`);
                     }
                     return response.json();
                 })
                 .then(data => {
-                    console.log('All dashboards data:', data); // Debug log
                     if (data.success) {
                         currentDashboards = data.dashboards;
-                        console.log('Current dashboards:', currentDashboards); // Debug log
                         renderDashboards('admin');
                         renderDashboards('cre');
                         renderDashboards('ps');
@@ -378,7 +374,6 @@
 
         // Render dashboards for a specific type
         function renderDashboards(type) {
-            console.log(`Rendering dashboards for type: ${type}`); // Debug log
             let containerId;
             if (type === 'branch-head') {
                 containerId = 'branchHeadDashboardsList';
@@ -386,18 +381,14 @@
                 containerId = type + 'DashboardsList';
             }
             const container = document.getElementById(containerId);
-            console.log(`Container for ${type} (ID: ${containerId}):`, container); // Debug log
             const dashboards = currentDashboards[type] || [];
-            console.log(`Dashboards for ${type}:`, dashboards); // Debug log
             
             if (dashboards.length === 0) {
-                console.log(`No dashboards found for type: ${type}`); // Debug log
                 container.innerHTML = `
                     <div class="empty-state">
                         <i class="fas fa-chart-bar"></i>
                         <h4>No dashboards configured</h4>
                         <p>Click "Add Dashboard" to configure your first Zoho dashboard embedding.</p>
-                        <small class="text-muted">Debug: Type ${type} has no dashboards</small>
                     </div>
                 `;
                 return;


### PR DESCRIPTION
We have finally implemented the use of Zoho Analytics to make dashboards based on our database for various roles like admin, CRE, P S, and Branch Heads. In this commit, we have added
a manage dashboards section in the admin dashboard. In this section, we can add the authorized links of the Zoho dashboards we want to display in the system, and it will display these dashboards in various logins, like -

If a dashboard link is added to the admin dashboards, the respective dashboard will be visible in the analytics section of the admin dashboard
If a dashboard link is added to the CRE dashboard, the respective dashboard will be visible in the analytics section of the CRE dashboard
If a dashboard link is added to the PS dashboard, the respective dashboard will be visible in the analytics section the PS dashboard
If a dashboard link is added to the Branch head dashboards, the respective dashboard will be visible in the Branch head login
For each section, you can add 5 dashboards with managed access to the dashboard.
This makes the dashboard truly dynamic.